### PR TITLE
Clarified Config, Fixed issue with copsamount

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -21,10 +21,10 @@ Config.Dispatch = 'qb' -- 'qb', 'ps', 'moz', 'cd', 'custom'
 -- what menu you want to use?
 Config.OxMenu = true -- true: Ox Menu, false: Ox Context Menu
 
--- Minimum cops required to sell drugs
+-- Minimum cops are required to sell drugs; leave this as 0 if you set Config.GiveBonusOnPolice to true
 Config.MinimumCops = 0
 
--- Give bonus on selling drugs when no of cops are online
+-- Give a bonus when selling drugs when a certain number of cops are on. Edit these numbers in Framework > server.lua. By default, it's 1.2 prices for more than 0, 1.5 more for more than 3, and 2.0 for more than 7.
 Config.GiveBonusOnPolice = false
 
 -- Allow selling to peds sitting in vehicle
@@ -36,7 +36,7 @@ Config.ChanceSell = 70 -- (in %)
 -- Random sell amount
 Config.RandomSell = { min = 1, max = 6 } -- range: min, max
 
--- Selling timeout so that the menu doesnt stay forever
+-- Selling timeout so that the menu doesn't stay forever
 Config.SellTimeout = 10 -- (secs) Max time you get to choose your option
 
 -- The below option decides whether the person has to toggle selling in a zone (radialmenu/command) (Recommended: false)

--- a/framework/server.lua
+++ b/framework/server.lua
@@ -22,7 +22,7 @@ if Config.Framework == 'qb' then
 			price = price * 1.2
 		elseif copsamount >= 3 and copsamount <= 6 then
 			price = price * 1.5
-		elseif copsamount >= 7 and copsamount <= 10 then
+		elseif copsamount >= 7 then
 			price = price * 2.0
 		end
         return price


### PR DESCRIPTION
elseif copsamount >= 7 and copsamount <= 10 then

It would break if there are more than 10 cops on - I've removed "copsamount <= 10" to allow for this bonus to persist for more than 10 police.

I've also modified the config to improve readability/understanding of the config for a minimum number of cops.